### PR TITLE
Additions for forms authentication cookie name

### DIFF
--- a/src/Nancy.Authentication.Forms.Tests/FormsAuthenticationFixture.cs
+++ b/src/Nancy.Authentication.Forms.Tests/FormsAuthenticationFixture.cs
@@ -75,11 +75,11 @@ namespace Nancy.Authentication.Forms.Tests
             };
 
             this.context = new NancyContext
-                               {
-                                    Request = new Request(
+            {
+                Request = new Request(
                                                     "GET",
                                                     new Url { Scheme = "http", BasePath = "/testing", HostName = "test.com", Path = "test" })
-                               };
+            };
 
             this.userGuid = new Guid("3D97EB33-824A-4173-A2C1-633AC16C1010");
         }
@@ -169,7 +169,7 @@ namespace Nancy.Authentication.Forms.Tests
 
             var result = FormsAuthentication.UserLoggedInRedirectResponse(context, userGuid);
 
-            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).Any().ShouldBeTrue();
+            result.Cookies.Where(c => c.Name == this.config.AuthenticationCookieName).Any().ShouldBeTrue();
         }
 
         [Fact]
@@ -182,7 +182,7 @@ namespace Nancy.Authentication.Forms.Tests
             var result = FormsAuthentication.UserLoggedInResponse(userGuid);
 
             // Then
-            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).Any().ShouldBeTrue();
+            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config)).Any().ShouldBeTrue();
         }
 
         [Fact]
@@ -195,7 +195,7 @@ namespace Nancy.Authentication.Forms.Tests
             var result = FormsAuthentication.UserLoggedInRedirectResponse(context, userGuid);
 
             //Then
-            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First()
+            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config)).First()
                 .HttpOnly.ShouldBeTrue();
         }
 
@@ -209,7 +209,7 @@ namespace Nancy.Authentication.Forms.Tests
             var result = FormsAuthentication.UserLoggedInResponse(userGuid);
 
             // Then
-            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First()
+            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config)).First()
                 .HttpOnly.ShouldBeTrue();
         }
 
@@ -220,7 +220,7 @@ namespace Nancy.Authentication.Forms.Tests
 
             var result = FormsAuthentication.UserLoggedInRedirectResponse(context, userGuid);
 
-            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First()
+            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config)).First()
                 .Expires.ShouldBeNull();
         }
 
@@ -234,7 +234,7 @@ namespace Nancy.Authentication.Forms.Tests
             var result = FormsAuthentication.UserLoggedInResponse(userGuid);
 
             // Then
-            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First()
+            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config)).First()
                 .Expires.ShouldBeNull();
         }
 
@@ -245,7 +245,7 @@ namespace Nancy.Authentication.Forms.Tests
 
             var result = FormsAuthentication.UserLoggedInRedirectResponse(context, userGuid, DateTime.Now.AddDays(1));
 
-            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First()
+            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config)).First()
                 .Expires.ShouldNotBeNull();
         }
 
@@ -259,7 +259,7 @@ namespace Nancy.Authentication.Forms.Tests
             var result = FormsAuthentication.UserLoggedInResponse(userGuid, DateTime.Now.AddDays(1));
 
             // Then
-            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First()
+            result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config)).First()
                 .Expires.ShouldNotBeNull();
         }
 
@@ -361,7 +361,7 @@ namespace Nancy.Authentication.Forms.Tests
 
             var result = FormsAuthentication.LogOutAndRedirectResponse(context, "/");
 
-            var cookie = result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First();
+            var cookie = result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config)).First();
             cookie.Value.ShouldBeEmpty();
             cookie.Expires.ShouldNotBeNull();
             (cookie.Expires < DateTime.Now).ShouldBeTrue();
@@ -377,7 +377,7 @@ namespace Nancy.Authentication.Forms.Tests
             var result = FormsAuthentication.LogOutResponse();
 
             // Then
-            var cookie = result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First();
+            var cookie = result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config)).First();
             cookie.Value.ShouldBeEmpty();
             cookie.Expires.ShouldNotBeNull();
             (cookie.Expires < DateTime.Now).ShouldBeTrue();
@@ -390,7 +390,7 @@ namespace Nancy.Authentication.Forms.Tests
             var mockMapper = A.Fake<IUserMapper>();
             this.config.UserMapper = mockMapper;
             FormsAuthentication.Enable(fakePipelines, this.config);
-            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName, this.validCookieValue);
+            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName(this.config), this.validCookieValue);
 
             fakePipelines.BeforeRequest.Invoke(this.context, new CancellationToken());
 
@@ -403,11 +403,11 @@ namespace Nancy.Authentication.Forms.Tests
         {
             var fakePipelines = new Pipelines();
             var fakeMapper = A.Fake<IUserMapper>();
-            var fakeUser = new FakeUserIdentity {UserName = "Bob"};
+            var fakeUser = new FakeUserIdentity { UserName = "Bob" };
             A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.userGuid, this.context)).Returns(fakeUser);
             this.config.UserMapper = fakeMapper;
             FormsAuthentication.Enable(fakePipelines, this.config);
-            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName, this.validCookieValue);
+            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName(this.config), this.validCookieValue);
 
             var result = fakePipelines.BeforeRequest.Invoke(this.context, new CancellationToken());
 
@@ -419,11 +419,11 @@ namespace Nancy.Authentication.Forms.Tests
         {
             var fakePipelines = new Pipelines();
             var fakeMapper = A.Fake<IUserMapper>();
-            var fakeUser = new FakeUserIdentity {UserName = "Bob"};
+            var fakeUser = new FakeUserIdentity { UserName = "Bob" };
             A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.userGuid, this.context)).Returns(fakeUser);
             this.config.UserMapper = fakeMapper;
             FormsAuthentication.Enable(fakePipelines, this.config);
-            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName, string.Empty);
+            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName(this.config), string.Empty);
 
             var result = fakePipelines.BeforeRequest.Invoke(this.context, new CancellationToken());
 
@@ -439,7 +439,7 @@ namespace Nancy.Authentication.Forms.Tests
             A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.userGuid, this.context)).Returns(fakeUser);
             this.config.UserMapper = fakeMapper;
             FormsAuthentication.Enable(fakePipelines, this.config);
-            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName, this.cookieWithInvalidHmac);
+            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName(this.config), this.cookieWithInvalidHmac);
 
             var result = fakePipelines.BeforeRequest.Invoke(this.context, new CancellationToken());
 
@@ -455,7 +455,7 @@ namespace Nancy.Authentication.Forms.Tests
             A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.userGuid, this.context)).Returns(fakeUser);
             this.config.UserMapper = fakeMapper;
             FormsAuthentication.Enable(fakePipelines, this.config);
-            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName, this.cookieWithEmptyHmac);
+            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName(this.config), this.cookieWithEmptyHmac);
 
             var result = fakePipelines.BeforeRequest.Invoke(this.context, new CancellationToken());
 
@@ -471,7 +471,7 @@ namespace Nancy.Authentication.Forms.Tests
             A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.userGuid, this.context)).Returns(fakeUser);
             this.config.UserMapper = fakeMapper;
             FormsAuthentication.Enable(fakePipelines, this.config);
-            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName, this.cookieWithNoHmac);
+            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName(this.config), this.cookieWithNoHmac);
 
             var result = fakePipelines.BeforeRequest.Invoke(this.context, new CancellationToken());
 
@@ -487,7 +487,7 @@ namespace Nancy.Authentication.Forms.Tests
             A.CallTo(() => fakeMapper.GetUserFromIdentifier(this.userGuid, this.context)).Returns(fakeUser);
             this.config.UserMapper = fakeMapper;
             FormsAuthentication.Enable(fakePipelines, this.config);
-            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName, this.cookieWithBrokenEncryptedData);
+            this.context.Request.Cookies.Add(FormsAuthentication.FormsAuthenticationCookieName(this.config), this.cookieWithBrokenEncryptedData);
 
             var result = fakePipelines.BeforeRequest.Invoke(this.context, new CancellationToken());
 
@@ -610,7 +610,7 @@ namespace Nancy.Authentication.Forms.Tests
 
             //Then
             result.Cookies
-                    .Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName)
+                    .Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config))
                     .First()
                     .Secure.ShouldBeTrue();
         }
@@ -626,7 +626,7 @@ namespace Nancy.Authentication.Forms.Tests
 
             // Then
             result.Cookies
-                    .Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName)
+                    .Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config))
                     .First()
                     .Secure.ShouldBeTrue();
         }
@@ -638,7 +638,7 @@ namespace Nancy.Authentication.Forms.Tests
 
             var result = FormsAuthentication.LogOutAndRedirectResponse(context, "/");
 
-            var cookie = result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First();
+            var cookie = result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config)).First();
             cookie.Secure.ShouldBeTrue();
         }
 
@@ -652,7 +652,7 @@ namespace Nancy.Authentication.Forms.Tests
             var result = FormsAuthentication.LogOutResponse();
 
             // Then
-            var cookie = result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First();
+            var cookie = result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config)).First();
             cookie.Secure.ShouldBeTrue();
         }
 
@@ -675,7 +675,7 @@ namespace Nancy.Authentication.Forms.Tests
             FormsAuthentication.Enable(A.Fake<IPipelines>(), this.config);
             context.Request.Query[config.RedirectQuerystringKey] = "http://moo.com/";
 
-            var result = FormsAuthentication.UserLoggedInRedirectResponse(context, userGuid, fallbackRedirectUrl:"/moo");
+            var result = FormsAuthentication.UserLoggedInRedirectResponse(context, userGuid, fallbackRedirectUrl: "/moo");
 
             result.ShouldBeOfType(typeof(Response));
             result.StatusCode.ShouldEqual(HttpStatusCode.SeeOther);
@@ -705,7 +705,7 @@ namespace Nancy.Authentication.Forms.Tests
             var result = FormsAuthentication.UserLoggedInRedirectResponse(context, userGuid);
 
             //Then
-            var cookie = result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First();
+            var cookie = result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config)).First();
             cookie.Domain.ShouldEqual(domain);
         }
 
@@ -719,7 +719,7 @@ namespace Nancy.Authentication.Forms.Tests
             var result = FormsAuthentication.UserLoggedInRedirectResponse(context, userGuid);
 
             //Then
-            var cookie = result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName).First();
+            var cookie = result.Cookies.Where(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(this.config)).First();
             cookie.Path.ShouldEqual(path);
         }
 

--- a/src/Nancy.Authentication.Forms/FormsAuthenticationConfiguration.cs
+++ b/src/Nancy.Authentication.Forms/FormsAuthenticationConfiguration.cs
@@ -102,5 +102,10 @@ namespace Nancy.Authentication.Forms
                 return true;
             }
         }
+
+        /// <summary>
+        /// Specify authentication cookie name. If not specify the default will be used
+        /// </summary>
+        public string AuthenticationCookieName { get; set; }
     }
 }

--- a/src/Nancy.Testing.Tests/BrowserFixture.cs
+++ b/src/Nancy.Testing.Tests/BrowserFixture.cs
@@ -430,9 +430,9 @@ namespace Nancy.Testing.Tests
                 with.FormsAuth(userId, formsAuthConfig);
             });
 
-            var cookie = response.Cookies.Single(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName);
+            var cookie = response.Cookies.Single(c => c.Name == FormsAuthentication.FormsAuthenticationCookieName(formsAuthConfig));
             var cookieValue = HttpUtility.UrlDecode(cookie.Value);
-            
+
             //Then
             cookieValue.ShouldEqual(cookieContents);
         }
@@ -531,14 +531,14 @@ namespace Nancy.Testing.Tests
             // When
             var result = browser.Get("/useragent", with =>
             {
-                with.Header("User-Agent", expectedHeaderValue);    
+                with.Header("User-Agent", expectedHeaderValue);
             });
 
             var header = result.Body.AsString();
 
             // Then
             header.ShouldEqual(expectedHeaderValue);
-        }     
+        }
 
         public class EchoModel
         {
@@ -556,14 +556,14 @@ namespace Nancy.Testing.Tests
                     {
                         var body = new StreamReader(this.Context.Request.Body).ReadToEnd();
                         return new Response
-                                {
-                                    Contents = stream =>
-                                                {
-                                                    var writer = new StreamWriter(stream);
-                                                    writer.Write(body);
-                                                    writer.Flush();
-                                                }
-                                };
+                        {
+                            Contents = stream =>
+                                        {
+                                            var writer = new StreamWriter(stream);
+                                            writer.Write(body);
+                                            writer.Flush();
+                                        }
+                        };
                     };
 
                 Get["/cookie"] = ctx =>
@@ -605,7 +605,7 @@ namespace Nancy.Testing.Tests
                 Get["/type"] = _ => this.Request.Url.Scheme.ToLower();
 
                 Get["/ajax"] = _ => this.Request.IsAjaxRequest() ? "ajax" : "not-ajax";
- 
+
                 Post["/encoded"] = parameters => (string)this.Request.Form.name;
 
                 Post["/encodedquerystring"] = parameters => (string)this.Request.Query.name;

--- a/src/Nancy.Testing/BrowserContextExtensions.cs
+++ b/src/Nancy.Testing/BrowserContextExtensions.cs
@@ -167,7 +167,7 @@ namespace Nancy.Testing
 
             var cookieContents = String.Format("{1}{0}", encryptedId, hmacString);
 
-            Cookie(browserContext, FormsAuthentication.FormsAuthenticationCookieName, cookieContents);
+            Cookie(browserContext, FormsAuthentication.FormsAuthenticationCookieName(formsAuthenticationConfiguration), cookieContents);
         }
 
         public static void Accept(this BrowserContext browserContext, MediaRange mediaRange)
@@ -187,7 +187,7 @@ namespace Nancy.Testing
                     if (contextValues.Headers["accept"].Any(x => x.Equals("*/*")))
                     {
                         contextValues.Headers.Remove("accept");
-                    }    
+                    }
                 }
             }
 


### PR DESCRIPTION
Added property in ```FormsAuthenticationConfiguration ``` in order to specify authentication cookie name, so we can have multiple nancy instances on the same domain using ```FormsAuthentication```.

If the cookie name is not specified, nancy uses the default ```"_ncfa"``
